### PR TITLE
Syntax error when the function declaration is included

### DIFF
--- a/manuscript/chapter2.txt
+++ b/manuscript/chapter2.txt
@@ -306,7 +306,7 @@ But now you need to pass the query property to your evaluation process. That's w
 {lang=javascript}
 ~~~~~~~~
 # leanpub-start-insert
-function isSearched(query) {
+isSearched(query) {
   return function(item) {
     return !query || item.title.toLowerCase().includes(query.toLowerCase());
   }


### PR DESCRIPTION
When compiling with the function declaration, I get the following error:
```
Compiling...
Failed to compile.

Error in ./src/App.js
Syntax error: Unexpected token, expected ( (59:11)

  57 |   }
  58 |
> 59 |   function isSearched(query) {
     |            ^
  60 |     return function(item) {
  61 |       return true
  62 |     }

 @ ./src/index.js 13:11-27
```

Removing the function declaration resolved the issue and the resulting functionality is as intended.