### PR TITLE
`var` usage in ES6 replaced with `const`

### DIFF
--- a/manuscript/chapter2.txt
+++ b/manuscript/chapter2.txt
@@ -116,7 +116,7 @@ var userService = {
 };
 
 // ES6
-var userService = {
+const userService = {
   getUserName(user) {
     return user.firstname + ' ' + user.lastname;
   },
@@ -133,8 +133,8 @@ var user = {
 };
 
 // ES6
-var key = 'name';
-var user = {
+const key = 'name';
+const user = {
   [key]: 'Robin',
 };
 ~~~~~~~~
@@ -562,7 +562,7 @@ var firstname = user.firstname;
 var lastname = user.lastname;
 
 // ES6
-var { firstname, lastname } = user;
+const { firstname, lastname } = user;
 
 console.log(firstname + ' ' + lastname);
 // output: Robin Wieruch
@@ -572,7 +572,7 @@ While you have to add an extra line each time you want to access an object prope
 
 {lang=javascript}
 ~~~~~~~~
-var {
+const {
   firstname,
   lastname
 } = user;
@@ -582,8 +582,8 @@ The same goes for arrays. You can destructure them too, but keep it more readabl
 
 {lang=javascript}
 ~~~~~~~~
-var users = ['Robin', 'Andrew', 'Dan'];
-var [
+const users = ['Robin', 'Andrew', 'Dan'];
+const [
   userOne,
   userTwo,
   userThree
@@ -622,7 +622,7 @@ var searchTerm = this.state.searchTerm;
 var list = this.state.list;
 
 // ES6
-var { searchTerm, list } = this.state;
+const { searchTerm, list } = this.state;
 ~~~~~~~~
 
 But since the book uses ES6 most of the time, you should stick to ES6.

--- a/manuscript/chapter3.txt
+++ b/manuscript/chapter3.txt
@@ -70,7 +70,7 @@ In ES6 JavaScript you can use [template strings](https://developer.mozilla.org/e
 {lang=javascript}
 ~~~~~~~~
 // ES6
-var url = `${PATH_BASE}${PATH_SEARCH}?${PARAM_SEARCH}${DEFAULT_QUERY}`;
+const url = `${PATH_BASE}${PATH_SEARCH}?${PARAM_SEARCH}${DEFAULT_QUERY}`;
 
 // ES5
 var url = PATH_BASE + PATH_SEARCH + '?' + PARAM_SEARCH + DEFAULT_QUERY;
@@ -559,7 +559,7 @@ Now you can use these constants to add the page parameter to your API request.
 
 {lang=javascript}
 ~~~~~~~~
-var url = `${PATH_BASE}${PATH_SEARCH}?${PARAM_SEARCH}${searchTerm}&${PARAM_PAGE}`;
+const url = `${PATH_BASE}${PATH_SEARCH}?${PARAM_SEARCH}${searchTerm}&${PARAM_PAGE}`;
 
 // output
 console.log(url);


### PR DESCRIPTION
`var` in ES6 replaced with `const` on chapter 2 and 3.
