### PR TITLE
Ch5 typos

### DIFF
--- a/manuscript/chapter5.md
+++ b/manuscript/chapter5.md
@@ -335,7 +335,7 @@ const withLoading = (Component) => (props) =>
 
 Based on the loading property you can apply a conditional rendering. The function will return the Loading component or the input component.
 
-In general it can be very efficient to spread an object, life the props object, as input for a component. See the difference in the following code snippet.
+In general it can be very efficient to spread an object, like the props object, as input for a component. See the difference in the following code snippet.
 
 {title="Code Playground",lang="javascript"}
 ~~~~~~~~

--- a/manuscript/chapter5.md
+++ b/manuscript/chapter5.md
@@ -359,7 +359,7 @@ const withLoading = (Component) => ({ isLoading, ...rest }) =>
 
 It takes one property out of the object, but keeps the remaining object. It works with multiple properties as well. You might have already read about it in the [destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 
-Now you can use the HOC in your JSX. A use case in the appliaction could be to show either the "More" button or the Loading component. The Loading component is already encapsulated in the HOC, but an input component is missing. In the use case of showing a Button component or a Loading component, the Button is the input component of the HOC. The enhanced output component is a ButtonWithLoading component.
+Now you can use the HOC in your JSX. A use case in the application could be to show either the "More" button or the Loading component. The Loading component is already encapsulated in the HOC, but an input component is missing. In the use case of showing a Button component or a Loading component, the Button is the input component of the HOC. The enhanced output component is a ButtonWithLoading component.
 
 {title="src/App.js",lang=javascript}
 ~~~~~~~~


### PR DESCRIPTION
There were a couple typos that I ran across while reading through this chapter. I started this branch about mid-way through the chapter so I may not have caught them all.

I also had a thought. Might it be better to wrap more code terms that are in-text with back-ticks so they appear in monospace font and are easier to pick out? You already do this for a few terms like `sortKey` and `isSortReverse`. It could be extended to the components as well. For example, when the Table component is mentioned, yes it should be obvious you're talking about the `<Table />` component. But it might be even more obvious if in-text it's mentioned as `Table`