### PR TITLE
Ch6 typos

### DIFF
--- a/manuscript/chapter6.md
+++ b/manuscript/chapter6.md
@@ -1,6 +1,6 @@
 # State Management in React and beyond
 
-You have learned the basics of state management in React already in the previous chapters. This chapter digs a bit deeper into the topic. You will learn best practices, how to apply them and why you could consider an third party state management library.
+You have learned the basics of state management in React already in the previous chapters. This chapter digs a bit deeper into the topic. You will learn best practices, how to apply them and why you could consider using a third party state management library.
 
 ## Lifting State
 

--- a/manuscript/chapter6.md
+++ b/manuscript/chapter6.md
@@ -460,7 +460,7 @@ In a growing application it gets harder to reason about state changes. You can i
 
 Because of all these reasons, there exist standalone solutions to take care of the state management. These solutions are not only used in React. However, that's what makes the React ecosystem such a powerful place. You can use different solutions to solve your problems. To address the problem of scaling state management, you might have heard of the libraries [Redux](http://redux.js.org/docs/introduction/) or [MobX](https://mobx.js.org/). You can use either of these solutions in a React application. They come with extensions, [react-redux](https://github.com/reactjs/react-redux) and [mobx-react](https://github.com/mobxjs/mobx-react), to integrate with React.
 
-Redux and MobX are outside of the scope of this book. When you finished the book, you will get guidance how you can continue to learn React and its ecosystem. One learning path could be to learn Redux. Before you dive into the topic of external state management, I can recommend to read this [article](https://www.robinwieruch.de/redux-mobx-confusion/). It aims to give you a better understanding of how to learn external state management.
+Redux and MobX are outside of the scope of this book. When you have finished the book, you will get guidance on how you can continue to learn React and its ecosystem. One learning path could be to learn Redux. Before you dive into the topic of external state management, I can recommend to read this [article](https://www.robinwieruch.de/redux-mobx-confusion/). It aims to give you a better understanding of how to learn external state management.
 
 ### Exercises:
 

--- a/manuscript/chapter6.md
+++ b/manuscript/chapter6.md
@@ -10,7 +10,7 @@ The sort functionality is only handled in the Table component. You could move it
 
 In order to deal with state and methods in the Table component, it has to become an ES6 class component. The refactoring from functional stateless component to ES6 class component is straight forward.
 
-Your Table component as functional stateless component:
+Your Table component as a functional stateless component:
 
 {title="src/App.js",lang=javascript}
 ~~~~~~~~


### PR DESCRIPTION
A small handful of typos and grammar changes in chapter 6. Line-editing would be more clear if each sentence was on a separate line instead of blocking a paragraph out all on one line.