### PR TITLE
Moved missing const isSearched

### DIFF
--- a/manuscript/chapter2.md
+++ b/manuscript/chapter2.md
@@ -772,6 +772,9 @@ The second one is the Table component.
 
 # leanpub-start-insert
 class Table extends Component {
+  const isSearched = (searchTerm) => (item) =>
+    !searchTerm || item.title.toLowerCase().includes(searchTerm.toLowerCase());
+
   render() {
     const { list, pattern, onDismiss } = this.props;
     return (
@@ -907,6 +910,9 @@ Since you already have a button element, you can use the Button component instea
 {title="src/App.js",lang=javascript}
 ~~~~~~~~
 class Table extends Component {
+  const isSearched = (searchTerm) => (item) =>
+    !searchTerm || item.title.toLowerCase().includes(searchTerm.toLowerCase());
+
   render() {
     const { list, pattern, onDismiss } = this.props;
     return (
@@ -1220,6 +1226,9 @@ Second, apply it in your Table functional stateless component.
 {title="src/App.js",lang=javascript}
 ~~~~~~~~
 const Table = ({ list, pattern, onDismiss }) =>
+  const isSearched = (searchTerm) => (item) =>
+    !searchTerm || item.title.toLowerCase().includes(searchTerm.toLowerCase());
+
 # leanpub-start-insert
   <div className="table">
 # leanpub-end-insert
@@ -1259,6 +1268,9 @@ Let's keep the Table column width flexible by using inline style.
 {title="src/App.js",lang=javascript}
 ~~~~~~~~
 const Table = ({ list, pattern, onDismiss }) =>
+  const isSearched = (searchTerm) => (item) =>
+    !searchTerm || item.title.toLowerCase().includes(searchTerm.toLowerCase());
+
   <div className="table">
     { list.filter(isSearched(pattern)).map(item =>
       <div key={item.objectID} className="table-row">


### PR DESCRIPTION
## Problem
In chapter 2, we refactor out the `<Table>` component, which relies on the `isSearched` const that we had originally defined in the `App` component.  However, when we refactor the `<Table>` component out, we need to bring `isSearched` along with it, or else we will leave the page in a broken state as we leave chapter 2.  This required move may not be obvious to beginners and a beginner would likely anticipate a working page at the end of each chapter.

## Solution
I added the missing const in each position that it should now reside after the refactor.   I _seems_ obvious enough that it is being moved and not duplicated, but it may also be worth adding a comment in the first occurrence spelling this out.