### PR TITLE
Add yarn.lock file and note Yarn is used by default.

### DIFF
--- a/manuscript/chapter1.md
+++ b/manuscript/chapter1.md
@@ -203,7 +203,7 @@ A short break down of the folders and files. It is fine if you don't understand 
 
 * **package.json:** The file shows you a list of node package dependencies and other project configuration.
 
-* **yarn.lock:** By default, if Yarn is installed, create-react-app uses Yarn as a package manager. If you don't have Yarn installed then create-react-app will use the NPM package manager. If you have both Yarn and NPM package managers installed you can use the Node package manager by adding --use-npm to the create-react-app command. You don't need to worry about this file for now.
+* **yarn.lock:** By default, if Yarn is installed, create-react-app uses Yarn as a package manager. If you don't have Yarn installed then create-react-app will use the Node package manager. If you have both Yarn and Node package managers installed you can use the Node package manager by adding --use-npm to the create-react-app command. You don't need to worry about this file for now.
 
 * **.gitignore:** The file indicates all files and folders that shouldn't be added to your git repository when using git. They should only live in your local project. The *node_modules/* folder is such a use case. It is sufficient to share the *package.json* file with your peers to enable them to install all dependencies on their own without sharing the whole dependency folder.
 

--- a/manuscript/chapter1.md
+++ b/manuscript/chapter1.md
@@ -203,6 +203,8 @@ A short break down of the folders and files. It is fine if you don't understand 
 
 * **package.json:** The file shows you a list of node package dependencies and other project configuration.
 
+* **yarn.lock:** By default, create-react-app uses the Yarn as a package manager. You can use the Node package manager by adding --use-npm to the create-react-app command. You don't need to worry about this file for now. If you want to learn more about migrating from Node package manager to Yarn package manager, see https://yarnpkg.com/en/docs/migrating-from-npm.
+
 * **.gitignore:** The file indicates all files and folders that shouldn't be added to your git repository when using git. They should only live in your local project. The *node_modules/* folder is such a use case. It is sufficient to share the *package.json* file with your peers to enable them to install all dependencies on their own without sharing the whole dependency folder.
 
 * **public/:** The folder holds development root files, such as *public/index.html*. This index is the one displayed on localhost:3000 when developing your app. The boilerplate takes care of relating this index with all the scripts in *src/*.

--- a/manuscript/chapter1.md
+++ b/manuscript/chapter1.md
@@ -203,7 +203,7 @@ A short break down of the folders and files. It is fine if you don't understand 
 
 * **package.json:** The file shows you a list of node package dependencies and other project configuration.
 
-* **yarn.lock:** By default, create-react-app uses the Yarn as a package manager. You can use the Node package manager by adding --use-npm to the create-react-app command. You don't need to worry about this file for now. If you want to learn more about migrating from Node package manager to Yarn package manager, see https://yarnpkg.com/en/docs/migrating-from-npm.
+* **yarn.lock:** By default, if Yarn is installed, create-react-app uses Yarn as a package manager. If you don't have Yarn installed then create-react-app will use the NPM package manager. If you have both Yarn and NPM package managers installed you can use the Node package manager by adding --use-npm to the create-react-app command. You don't need to worry about this file for now.
 
 * **.gitignore:** The file indicates all files and folders that shouldn't be added to your git repository when using git. They should only live in your local project. The *node_modules/* folder is such a use case. It is sufficient to share the *package.json* file with your peers to enable them to install all dependencies on their own without sharing the whole dependency folder.
 


### PR DESCRIPTION
Add node that create-react-app uses Yarn by default now but you can add --use-npm to have it use NPM when creating a ReactJS app.