### PR TITLE
Change heading level for translations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The official repository for [The Road to learn React](https://www.robinwieruch.de/the-road-to-learn-react/). In addition, here you can find the [Source Code](https://github.com/the-road-to-learn-react/hackernews-client) and [Complete Course](https://roadtoreact.com/). If you want to leave a review, you can do it on [Amazon](https://www.amazon.com/dp/B077HJFCQX?tag=21moves-20) or [Goodreads](https://www.goodreads.com/book/show/37503118-the-road-to-learn-react). This book is hosted on [Leanpub](https://leanpub.com/the-road-to-learn-react) as well.
 
-# Translations of the book into Leanpub
+## Translations of the book into Leanpub
 
 The Road to learn React is also available in other languages. Thanks for all translators for their awesome work!
 


### PR DESCRIPTION
Oops, I was wrong, there should be a second-level heading :man_facepalming: 