### PR TITLE
Enabled syntax highlighting

### DIFF
--- a/manuscript/chapter1.md
+++ b/manuscript/chapter1.md
@@ -106,8 +106,8 @@ There are many approaches to getting started with a React application. The first
 
 To get started with React by using a CDN, find the `<script>` tag in your web page HTML that points to a CDN url. You will need two libraries: *react* and *react-dom*.
 
-{title="Code Playground",lang="javascript"}
-~~~~~~~~
+{title="Code Playground",lang="html"}
+~~~~~~~~html
 <script
   crossorigin
   src="https://unpkg.com/react@16/umd/react.development.js"
@@ -236,7 +236,7 @@ The scripts are defined in your *package.json*, and your basic React application
 Now we will get to know JSX, the syntax in React. As mentioned before, *create-react-app* has already bootstrapped a basic application for you, and all files come with their own default implementations. For now, the only file we will modify is the *src/App.js* file.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import logo from './logo.svg';
 import './App.css';
@@ -272,7 +272,7 @@ Don't worry if you're confused by the import/export statements and class declara
 In the file you should see a **React ES6 class component** with the name App. This is a component declaration. After you have declared a component, you can use it as an element anywhere in your application. It will produce an **instance** of your **component** or, in other words, the component gets instantiated.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // component declaration
 class App extends Component {
   ...
@@ -290,7 +290,7 @@ You should see where the App component is instantiated, else you couldn't see th
 The content in the render block may look similar to HTML, but it is actually JSX. JSX allows you to mix HTML and JavaScript. It is powerful, but it can be confusing when you are used to separating the two languages. It is a good idea to start by using basic HTML in your JSX. Open the `App.js` file and remove all unnecessary HTML code as shown:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import './App.css';
 
@@ -310,7 +310,7 @@ export default App;
 Now, you only return HTML in your `render()` method without any JavaScript. Let's define the "Welcome to the Road to learn React" as a variable. A variable is set in JSX by curly braces.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import './App.css';
 
@@ -351,7 +351,7 @@ You might have noticed the `className` attribute. It reflects the standard `clas
 Notice that we declared the variable `helloWorld` with a `var` statement. JavaScript ES6 comes with two more ways to declare variables: `const` and `let`. In JavaScript ES6, you will rarely find `var` anymore. A variable declared with `const` cannot be re-assigned or re-declared, and cannot be changed or modified. Once the variable is assigned, you cannot change it:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // not allowed
 const helloWorld = 'Welcome to the Road to learn React';
 helloWorld = 'Bye Bye React';
@@ -360,7 +360,7 @@ helloWorld = 'Bye Bye React';
 Conversely, a variable declared with `let` can be modified:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // allowed
 let helloWorld = 'Welcome to the Road to learn React';
 helloWorld = 'Bye Bye React';
@@ -371,7 +371,7 @@ helloWorld = 'Bye Bye React';
 Note that a variable declared directly with `const` cannot be modified. However, when the variable is an array or object, the values it holds can get updated through indirect means:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // allowed
 const helloWorld = {
   text: 'Welcome to the Road to learn React'
@@ -382,7 +382,7 @@ helloWorld.text = 'Bye Bye React';
 There are varying opinions about when to use *const* and when to use *let*. I would recommend using `const` whenever possible to show the intent of keeping your data structures immutable, so you only have to worry about the values contained in objects and arrays. Immutability is embraced in the React ecosystem, so `const` should be your default choice when you define a variable, though it's not really about immutability, but about assigning variables only once. It shows the intent of not changing (re-assigning) the variable even though its content can be changed.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import './App.css';
 
@@ -419,7 +419,7 @@ In your application, we will use `const` and `let` over `var` for the rest of th
 The App component is located in your entry point to the React world: the *src/index.js* file.
 
 {title="src/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
@@ -436,7 +436,7 @@ ReactDOM.render(
 `ReactDOM.render()` expects two arguments. The first argument is for rendering the JSX. The second argument specifies the place where the React application hooks into your HTML. It expects an element with an `id='root'`, found in the *public/index.html* file.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ReactDOM.render(
   <h1>Hello React World</h1>,
   document.getElementById('root')
@@ -457,7 +457,7 @@ Hot Module Replacement can be used in the *src/index.js* file to improve your ex
 Hot Module Replacement (HMR) is a tool for reloading your application in the browser without the page refresh. You can activate it in *create-react-app* by adding the following configuration to your *src/index.js* file:
 
 {title="src/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
@@ -495,7 +495,7 @@ So far, you have rendered a few primitive variables in your JSX. Now, we will re
 First you have to define the list of items:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import './App.css';
 
@@ -530,7 +530,7 @@ The sample data represents information we will fetch from an API later on. Items
 Now you can use the [built-in JavaScript map functionality](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) in JSX, which iterates over a list of items to display them according to specific attributes. Again, we use curly braces to encapsulate the JavaScript expression in JSX:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   render() {
     return (
@@ -551,7 +551,7 @@ export default App;
 Using JavaScript alongside HTML in JSX is very powerful. For a different task you may have used `map` to convert one list of items to another. This time, we used `map` to convert a list of items to HTML elements.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const array = [1, 4, 9, 16];
 
 // pass a function to map
@@ -564,7 +564,7 @@ console.log(newArray);
 So far, only the `title` is displayed for each item. Let's experiment with more of the item's properties:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   render() {
     return (
@@ -596,7 +596,7 @@ Note how the `map` function is inlined in your JSX. Each item property is displa
 React will display each item, but you can still do more to help React embrace its full potential. By assigning a key attribute to each list element, React can identify modified items when the list changes. These sample list items come with an identifier:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 {list.map(function(item) {
   return (
 # leanpub-start-insert
@@ -616,7 +616,7 @@ React will display each item, but you can still do more to help React embrace it
 Make sure that the key attribute is a stable identifier. Avoid using the index of the item in the array, because the array index is not stable. If the list changes its order, for example, React will not be able to identify the items properly.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // don't do this
 {list.map(function(item, key) {
   return (
@@ -642,7 +642,7 @@ Start your app in a browser, and you should see both items of the list displayed
 JavaScript ES6 introduced arrow functions expressions, which are shorter than a function expressions.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // function declaration
 function () { ... }
 
@@ -653,7 +653,7 @@ function () { ... }
 You can remove the parentheses in an arrow function expression if it only has one argument, but you have to keep the parentheses if it gets multiple arguments:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // allowed
 item => { ... }
 
@@ -670,7 +670,7 @@ item, key => { ... }
 You can also write `map` functions more concisely with an ES6 arrow function:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 {list.map(item => {
 # leanpub-end-insert
@@ -690,7 +690,7 @@ You can also write `map` functions more concisely with an ES6 arrow function:
 You can remove the *block body*, the curly braces, with the ES6 arrow function. In a *concise body*, an implicit return is attached; thus, you can remove the `return` statement. This will happen often in this book, so be sure to understand the difference between a block body and a concise body when using arrow functions.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 {list.map(item =>
 # leanpub-end-insert
@@ -724,7 +724,7 @@ While React embraces functional programming, e.g. immutable data structures and 
 Consider the following Developer class to examine a JavaScript ES6 class without a component.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Developer {
   constructor(firstname, lastname) {
     this.firstname = firstname;
@@ -742,7 +742,7 @@ A class has a constructor to make it instantiable. The constructor takes argumen
 The Developer class is the only class declaration we use here, as you can create multiple instances of a class by invoking it. It is similar to the ES6 class component, which has a declaration, but you have to use it somewhere else to instantiate it:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const robin = new Developer('Robin', 'Wieruch');
 console.log(robin.getName());
 // output: Robin Wieruch
@@ -751,7 +751,7 @@ console.log(robin.getName());
 React uses JavaScript ES6 classes for ES6 class components, which you have already used at least once so far:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 
 ...

--- a/manuscript/chapter2.md
+++ b/manuscript/chapter2.md
@@ -9,7 +9,7 @@ Local component state, also known as internal component state, allows you to sav
 Let's introduce a class constructor.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
 # leanpub-start-insert
@@ -29,7 +29,7 @@ It is mandatory to call `super(props);`. It sets `this.props` in your constructo
 
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const list = [
   {
     title: 'React',
@@ -62,7 +62,7 @@ class App extends Component {
 The state is bound to the class using the `this` object, so you can access the local state of the whole component. For instance, it can be used in the `render()` method. Previously you have mapped a static list of items in your `render()` method that was defined outside of your component. Now you are about to use the list from your local state in your component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -106,7 +106,7 @@ Be careful not to mutate the state directly. Instead, you should use a method ca
 In JavaScript ES6, you can use a shorthand property syntax to initialize your objects more concisely, like following object initialization:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const name = 'Robin';
 
 const user = {
@@ -117,7 +117,7 @@ const user = {
 When the property name in your object is the same as your variable name, you can do the following:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const name = 'Robin';
 
 const user = {
@@ -128,7 +128,7 @@ const user = {
 In your application, you can do the same. The list variable name and the state property name share the same name.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // ES5
 this.state = {
   list: list,
@@ -143,7 +143,7 @@ this.state = {
 Shorthand method names are also useful. In JavaScript ES6, you can initialize methods in an object more concisely:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // ES5
 var userService = {
   getUserName: function (user) {
@@ -162,7 +162,7 @@ const userService = {
 Finally, you are allowed to use computed property names in JavaScript ES6:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // ES5
 var user = {
   name: 'Robin',
@@ -191,7 +191,7 @@ Now you have a local state in your App component, but haven't manipulated the st
 We will practice this concept by adding a button for each item in the displayed list. The button will read "Dismiss", as its purpose will be to remove an item from the list. In an email client, for example, it would be a useful way to mark some list items as 'read' while keeping the unread items separate.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -232,7 +232,7 @@ Note the use of multilines for the button element, and how elements with multipl
 Now we will implement the `onDismiss()` functionality. It takes an id to identify the item to dismiss. The function is bound to the class and thus becomes a class method. That's why you access it with `this.onDismiss()` and not `onDismiss()`. The `this` object is your class instance. In order to define the `onDismiss()` as class method, you have to bind it in the constructor:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -256,7 +256,7 @@ class App extends Component {
 In the next step, we define its functionality, the business logic, in the class:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -286,7 +286,7 @@ Now we can define what happens inside a class method. Remember, the objective is
 You can remove an item from a list using [JavaScript's built-in filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) functionality, which takes a function as input. The function has access to each value in the list because it iterates over each item, so you can evaluate them based on certain conditions.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const words = ['spray', 'limit', 'elite', 'exuberant', 'destruction', 'present'];
 
 const filteredWords = words.filter(function (word) { return word.length > 6; });
@@ -298,7 +298,7 @@ console.log(filteredWords);
 The function returns a new list instead of mutating the old one, and it supports the React convention of using immutable data structures.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
 # leanpub-start-insert
   const updatedList = this.state.list.filter(function isNotId(item) {
@@ -311,7 +311,7 @@ onDismiss(id) {
 In the next step, we extract the function and pass it to the filter function:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
 # leanpub-start-insert
   function isNotId(item) {
@@ -326,7 +326,7 @@ onDismiss(id) {
 **Remember**: You can filter more efficiently using a JavaScript ES6 arrow function.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
 # leanpub-start-insert
   const isNotId = item => item.objectID !== id;
@@ -338,7 +338,7 @@ onDismiss(id) {
 You could even inline it again like you did in the `onClick` handler of the button, though it might get less readable:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
 # leanpub-start-insert
   const updatedList = this.state.list.filter(item => item.objectID !== id);
@@ -349,7 +349,7 @@ onDismiss(id) {
 The list removes the clicked item now, but the state hasn't updated yet. Use the `setState()` class method to update the list in the local component state:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
   const isNotId = item => item.objectID !== id;
   const updatedList = this.state.list.filter(isNotId);
@@ -372,7 +372,7 @@ Run the application again and try the "Dismiss" button. What you experienced is 
 It is important to learn about bindings in JavaScript classes when using React ES6 class components. In the previous chapter, you have bound your class method `onDismiss()` in the constructor.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   constructor(props) {
     super(props);
@@ -391,7 +391,7 @@ class App extends Component {
 The binding step is necessary because class methods don't automatically bind `this` to the class instance. Let's demonstrate it with the help of the following ES6 class component:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class ExplainBindingsComponent extends Component {
   onClickMe() {
     console.log(this);
@@ -415,7 +415,7 @@ The component renders just fine, but when you click the button, you see `undefin
 In the following class component the class method is properly bound in the class constructor:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class ExplainBindingsComponent extends Component {
 # leanpub-start-insert
   constructor() {
@@ -445,7 +445,7 @@ class ExplainBindingsComponent extends Component {
 Class method binding can happen somewhere else too. For instance, it can happen in the `render()` class method:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class ExplainBindingsComponent extends Component {
   onClickMe() {
     console.log(this);
@@ -471,7 +471,7 @@ Avoid this practice, however, because it binds the class method every time the `
 Some developers will define the business logic of their class methods in the constructor:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class ExplainBindingsComponent extends Component {
   constructor() {
     super();
@@ -499,7 +499,7 @@ class ExplainBindingsComponent extends Component {
 Avoid this approach as well, as it will clutter your constructor over time. The constructor is only there to instantiate your class with all its properties, so the business logic of class methods should be defined outside the constructor.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class ExplainBindingsComponent extends Component {
   constructor() {
     super();
@@ -523,7 +523,7 @@ class ExplainBindingsComponent extends Component {
 Class methods can be auto-bound using JavaScript ES6 arrow functions:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class ExplainBindingsComponent extends Component {
   onClickMe = () => {
     console.log(this);
@@ -554,7 +554,7 @@ Use this method if the repetitive binding in the constructor annoys you. The off
 Now we'll cover event handlers in elements. In your application, you are using the following button element to dismiss an item from the list.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 <button
@@ -570,7 +570,7 @@ Now we'll cover event handlers in elements. In your application, you are using t
 This function is already complex, because it passes a value to the class method and has to wrap it in another (arrow) function. Essentially, it has to be a function that is passed to the event handler. The following code wouldn't work, because the class method would be executed immediately when you open the application in the browser:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 <button
@@ -589,7 +589,7 @@ However, using `onClick={this.onDismiss}` wouldn't suffice, because the `item.ob
 
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 <button
@@ -605,7 +605,7 @@ However, using `onClick={this.onDismiss}` wouldn't suffice, because the `item.ob
 We can also define wrapping function outside the method, to pass only the defined function to the handler. Since it needs access to the individual item, it has to live inside the map function block.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -650,7 +650,7 @@ class App extends Component {
 A function has to be passed to the element's handler. As an example, try this code instead:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -681,7 +681,7 @@ class App extends Component {
 This method will run when you open the application in the browser, but not when you click the button. The following code would only run when you click the button, a function that is executed when you trigger the handler:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 <button
@@ -701,7 +701,7 @@ This method will run when you open the application in the browser, but not when 
 **Remember:** You can transform functions into a JavaScript ES6 arrow function, just as we did with the `onDismiss()` class method:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 <button
@@ -719,7 +719,7 @@ This method will run when you open the application in the browser, but not when 
 Newcomers to React often have difficulty using functions in event handlers, so don't get discouraged if you have trouble on the first pass. You should end up with an inlined JavaScript ES6 arrow function with access to the `objectID` property of the `item` object:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   ...
 
@@ -760,7 +760,7 @@ We'll add another interaction to see forms and events in React, a search functio
 In the first step, we define a form with an input field in JSX:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -787,7 +787,7 @@ In the following scenario you will type into the input field and filter the list
 Let's define a `onChange` handler for the input field:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -813,7 +813,7 @@ class App extends Component {
 The function is bound to the component, so it is a class method again. You just need to bind and define the method:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -842,7 +842,7 @@ class App extends Component {
 When using a handler in your element, you get access to the synthetic React event in your callback function's signature.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -860,7 +860,7 @@ class App extends Component {
 The event has the value of the input field in its target object, so you can update the local state with a search term using `this.setState()`.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -878,7 +878,7 @@ class App extends Component {
 Don't forget to define the initial state for the `searchTerm` property in the constructor. The input field should be empty in the beginning, so its value is an empty string.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -906,7 +906,7 @@ We can assume that when we update `searchTerm` with `this.setState()`, the list 
 Returning to the application, we see the list isn't filtered yet, based on the input field value stored in the local state. We need to filter the list temporarily based on the `searchTerm`, and we have everything we need to perform this operation. In the `render()` method, before mapping over the list, we apply a filter to it. The filter will only evaluate if the `searchTerm` matches the title property of the item. We've already used the built-in JavaScript filter functionality, so let's use it again to sneak in the filter function before the map function. The filter function returns a new array, so the map function can be used on it.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -938,7 +938,7 @@ It makes sense to know about higher-order functions, because React deals with a 
 First, you have to define the higher-order function outside of your App component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 function isSearched(searchTerm) {
   return function (item) {
@@ -959,7 +959,7 @@ The function takes the `searchTerm` and returns another function, because the fi
 It will also be used to filter the list based on the condition defined in the function, so let's define the condition:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 function isSearched(searchTerm) {
   return function (item) {
 # leanpub-start-insert
@@ -980,7 +980,7 @@ The condition matches the incoming `searchTerm` pattern with the title property 
 We cheated a bit using JavaScript ES7 features, but these aren't present in ES5. For ES5, use the `indexOf()` function to get the index of the item in the list instead. When the item is in the list, `indexOf()` will return its index in the array.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // ES5
 string.indexOf(pattern) !== -1
 
@@ -991,7 +991,7 @@ string.includes(pattern)
 Another neat refactoring can be done with an ES6 arrow function again. It makes the function more concise:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // ES5
 function isSearched(searchTerm) {
   return function (item) {
@@ -1009,7 +1009,7 @@ The React ecosystem uses a lot of functional programming concepts, often using f
 Last but not least, use the defined `isSearched()` function to filter lists. We pass it the `searchTerm` property from the local state, so that it returns the filter's input function and filters your list based on the filter condition. After that it maps over the filtered list to display an element for each list item.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1048,7 +1048,7 @@ The search functionality should work now. Try it yourself in the browser.
 Destructuring in JavaScript ES6 provides easier access to properties in objects and arrays. Compare the following snippet in JavaScript ES5 and ES6:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const user = {
   firstname: 'Robin',
   lastname: 'Wieruch',
@@ -1071,7 +1071,7 @@ console.log(firstname + ' ' + lastname);
 While we add an extra line each time we access an object property in JavaScript ES5, it takes just one line in JavaScript ES6. For readability, use multilines when you destructure an object into multiple properties.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const {
   firstname,
   lastname
@@ -1081,7 +1081,7 @@ const {
 The same concept applies to arrays. You can destructure them, too, again using multilines to keep your code scannable and readable.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const users = ['Robin', 'Andrew', 'Dan'];
 const [
   userOne,
@@ -1096,7 +1096,7 @@ console.log(userOne, userTwo, userThree);
 Note that the local state object in the App component can get destructured the same way. You can shorten the filter and map line of code.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
   render() {
 # leanpub-start-insert
     const { searchTerm, list } = this.state;
@@ -1116,7 +1116,7 @@ Note that the local state object in the App component can get destructured the s
 You can do it the ES5 or ES6 way:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // ES5
 var searchTerm = this.state.searchTerm;
 var list = this.state.list;
@@ -1142,7 +1142,7 @@ But didn't we forget something in the input element? An HTML input tag comes wit
 To do this, we set the value attribute of the input field, which is already saved in the `searchTerm` state property, so we can access it from there:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1183,7 +1183,7 @@ Local state management and unidirectional data flow might be new to you, but onc
 Now we have one large App component that keeps growing and may eventually become too complex to manage efficiently. We need to split it into smaller, more manageable parts by creating separate components for search input and the items list.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1205,7 +1205,7 @@ class App extends Component {
 We pass the components properties that they can use themselves. The App component needs to pass the properties managed in the local state and its class methods.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1236,7 +1236,7 @@ Now we define the components next to the App component, which will be done using
 The first one is the Search component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   ...
 }
@@ -1262,7 +1262,7 @@ class Search extends Component {
 The second one is the Table component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 # leanpub-start-insert
@@ -1311,7 +1311,7 @@ By extracting these components from the App component, they become reusable. Sin
 The `children` prop is used to pass elements to components from above, which are unknown to the component itself but make it possible to compose components together. We'll see how this looks when you pass a text string as a child to the Search component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1342,7 +1342,7 @@ class App extends Component {
 Now the Search component can destructure the `children` property from the `props` object, and specify where it should be displayed.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Search extends Component {
   render() {
 # leanpub-start-insert
@@ -1378,7 +1378,7 @@ Reusable and composable components empower you to come up with capable component
 Let's define one more reusable component, a Button component which we'll eventually reuse often:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Button extends Component {
   render() {
     const {
@@ -1405,7 +1405,7 @@ It might seem redundant to declare components like this, but it's not. We use a 
 Since you already have a button element, you can use the Button component instead. It omits the type attribute, because the Button component specifies it.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Table extends Component {
   render() {
     const { list, pattern, onDismiss } = this.props;
@@ -1437,7 +1437,7 @@ class Table extends Component {
 The Button component expects a `className` property in the `props`. The `className` attribute is another React derivate for the HTML attribute class. We didn't pass any `className` when the Button was used, though. It should be more explicit in our Button component that the `className` is optional, so we'll assign a default value in the object destructuring.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Button extends Component {
   render() {
     const {
@@ -1476,7 +1476,7 @@ When deciding when to use functional stateless components over ES6 class compone
 Returning to the application, we see the App component uses local state, so it has to stay as an ES6 class component. The other three ES6 class components are stateless, so they don't need access to `this.state` or `this.setState()`, and they have no lifecycle methods. We're going to refactor the Search component to a stateless functional component. The Table and Button component refactoring will become your exercise.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 function Search(props) {
   const { value, onChange, children } = props;
@@ -1496,7 +1496,7 @@ function Search(props) {
 The `props` are accessible in the function signature, and the return value is JSX; but we can do more with the code in a functional stateless component using ES6 destructuring. The best practice is to use it in the function signature to destructure the `props`:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 function Search({ value, onChange, children }) {
 # leanpub-end-insert
@@ -1515,7 +1515,7 @@ function Search({ value, onChange, children }) {
 Remember that ES6 arrow functions allow you to keep your functions concise and let you remove the block body of the function. In a concise body, an implicit return is attached, letting us remove the `return` statement. Since the functional stateless component is a function, it can be made more concise as well:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const Search = ({ value, onChange, children }) =>
   <form>
@@ -1531,7 +1531,7 @@ const Search = ({ value, onChange, children }) =>
 The last step is especially useful to enforce props as input and JSX as output. Still, you could *do something* in between by using a block body in your ES6 arrow function:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Search = ({ value, onChange, children }) => {
 
   // do something
@@ -1680,7 +1680,7 @@ Now we can use this style with some of our components. Remember to use React `cl
 First, apply it in your App ES6 class component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1717,7 +1717,7 @@ class App extends Component {
 Second, apply it in your Table functional stateless component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Table = ({ list, pattern, onDismiss }) =>
 # leanpub-start-insert
   <div className="table">
@@ -1756,7 +1756,7 @@ Now the application and components have been styled with basic CSS. Further, we 
 Let's keep the Table column width flexible by using inline style.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Table = ({ list, pattern, onDismiss }) =>
   <div className="table">
     {list.filter(isSearched(pattern)).map(item =>
@@ -1791,7 +1791,7 @@ const Table = ({ list, pattern, onDismiss }) =>
 The style is inlined now. Define the style objects outside of your elements to make it cleaner.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const largeColumn = {
   width: '40%',
 };

--- a/manuscript/chapter3.md
+++ b/manuscript/chapter3.md
@@ -65,7 +65,7 @@ Lastly, `componentDidCatch(error, info)` was introduced in [React 16](https://ww
 Now we're prepared to fetch data from the Hacker News API. There was one lifecycle method mentioned that can be used to fetch data: `componentDidMount()`. Before we use it, let's set up the URL constants and default parameters to break the URL endpoint for the API request into smaller pieces.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import './App.css';
 
@@ -83,7 +83,7 @@ const PARAM_SEARCH = 'query=';
 In JavaScript ES6, you can use [template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals) for string concatenation or interpolation. You will use it to concatenate your URL for the API endpoint.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // ES6
 const url = `${PATH_BASE}${PATH_SEARCH}?${PARAM_SEARCH}${DEFAULT_QUERY}`;
 
@@ -97,7 +97,7 @@ console.log(url);
 This will keep your URL composition flexible in the future. Below, the entire data fetch process will be presented, and each step will be explained afterward.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 class App extends Component {
@@ -151,7 +151,7 @@ Now you can use the fetched data instead of the sample list. Note that the resul
 In the next step, we use the result to render it. But we will prevent it from rendering anything, so we will return null, when there is no result in the first place. Once the request to the API has succeeded, the result is saved to the state and the App component will re-render with the updated state.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -200,7 +200,7 @@ The list of hits should now be visible in our application; however, two regressi
 The "Dismiss" button doesn't work because the `onDismiss()` method is not aware of the complex result object. It only knows about a plain list in the local state. But it isn't a plain list anymore. Let's change it to operate on the result object instead of the list itself.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
   const isNotId = item => item.objectID !== id;
 # leanpub-start-insert
@@ -217,7 +217,7 @@ In `setState()`, the result is now a complex object, and the list of hits is onl
 We could alleviate this challenge by mutating the hits in the result object. It is demonstrated below for the sake of understanding, but we'll end up using another way.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // don't do this
 this.state.result.hits = updatedHits;
 ~~~~~~~~
@@ -227,7 +227,7 @@ As we know, React embraces immutable data structures, so we don't want to mutate
 For this, we use JavaScript ES6's `Object.assign()`. It takes a target object as first argument. All following arguments are source objects, which are merged into the target object. The target object can be an empty object. It embraces immutability, because no source object gets mutated.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const updatedHits = { hits: updatedHits };
 const updatedResult = Object.assign({}, this.state.result, updatedHits);
 ~~~~~~~~
@@ -235,7 +235,7 @@ const updatedResult = Object.assign({}, this.state.result, updatedHits);
 Source objects will override previously merged objects with the same property names. Let's do this on the `onDismiss()` method:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
   const isNotId = item => item.objectID !== id;
   const updatedHits = this.state.result.hits.filter(isNotId);
@@ -252,7 +252,7 @@ That's one solution, but there is a simpler way in JavaScript ES6, called the *s
 We'll examine the ES6 **array** spread operator even though you don't need it yet:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const userList = ['Robin', 'Andrew', 'Dan'];
 const additionalUser = 'Jordan';
 const allUsers = [ ...userList, additionalUser ];
@@ -264,7 +264,7 @@ console.log(allUsers);
 The `allUsers` variable is a completely new array. The other variables `userList` and `additionalUser` stay the same. You can even merge two arrays into a new array.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const oldUsers = ['Robin', 'Andrew'];
 const newUsers = ['Dan', 'Jordan'];
 const allUsers = [ ...oldUsers, ...newUsers ];
@@ -276,7 +276,7 @@ console.log(allUsers);
 Now let's have a look at the object spread operator, which is not JavaScript ES6. It is part of a [proposal for a next JavaScript version](https://github.com/sebmarkbage/ecmascript-rest-spread) that is already being used by the React community, which is why *create-react-app* incorporated the feature in the configuration. The object spread operator works just like the JavaScript ES6 array spread operator, except with objects. Each key value pair is copied into a new object:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const userNames = { firstname: 'Robin', lastname: 'Wieruch' };
 const age = 28;
 const user = { ...userNames, age };
@@ -288,7 +288,7 @@ console.log(user);
 Multiple objects can be spread, as with the array spread example.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const userNames = { firstname: 'Robin', lastname: 'Wieruch' };
 const userAge = { age: 28 };
 const user = { ...userNames, ...userAge };
@@ -300,7 +300,7 @@ console.log(user);
 It can be used to replace `Object.assign()`:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onDismiss(id) {
   const isNotId = item => item.objectID !== id;
   const updatedHits = this.state.result.hits.filter(isNotId);
@@ -330,7 +330,7 @@ The `result` object in the local component state is `null` in the beginning. So 
 But let's go one step further. It makes more sense to wrap the Table component, which is the only component that depends on `result` in an independent conditional rendering. Everything else should be displayed, even though there is no `result` yet. You can simply use a [ternary operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) in the JSX:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -368,7 +368,7 @@ class App extends Component {
 That's your second option to express a conditional rendering. A third option is the logical `&&` operator. In JavaScript a `true && 'Hello World'` always evaluates to 'Hello World'. A `false && 'Hello World'` always evaluates to false.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const result = true && 'Hello World';
 console.log(result);
 // output: Hello World
@@ -381,7 +381,7 @@ console.log(result);
 In React, you can make use of that behavior. If the condition is true, the expression after the logical `&&` operator will be the output. If the condition is false, React ignores the expression. It is applicable in the Table component's conditional rendering case, because it should either return a Table or nothing.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 { result &&
   <Table
     list={result.hits}
@@ -409,7 +409,7 @@ Now, when you use the Search component with its input field, you will filter the
 You can define an `onSearchSubmit()` method in your App component, which fetches results from the Hacker News API when executing a search in the Search component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -443,7 +443,7 @@ class App extends Component {
 The `onSearchSubmit()` method should use the same functionality as the `componentDidMount()` lifecycle method, but this time with a modified search term from the local state and not with the initial default search term. Thus you can extract the functionality as a reusable class method.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -501,7 +501,7 @@ As an alternative, you could debounce (delay) the `onChange()` function and spar
 First, pass the `onSearchSubmit()` method to your Search component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -537,7 +537,7 @@ class App extends Component {
 Second, introduce a button in your Search component. The button has the `type="submit"` and the form uses its `onSubmit` attribute to pass the `onSubmit()` method. You can reuse the `children` property, but this time it will be used as the content of the button.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const Search = ({
   value,
@@ -561,7 +561,7 @@ const Search = ({
 In the Table, you can remove the filter functionality, because there will be no client-side filter (search) anymore. Don't forget to remove the `isSearched()` function as well, as it won't be used anymore. Now, the result comes directly from the Hacker News API when the user clicks the "Search" button.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -601,7 +601,7 @@ const Table = ({ list, onDismiss }) =>
 Now when you try to search, you will notice the browser reloads. That's a native browser behavior for a submit callback in an HTML form. In React, you will often come across the `preventDefault()` event method to suppress the native browser behavior.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 onSearchSubmit(event) {
 # leanpub-end-insert
@@ -629,7 +629,7 @@ Take a closer look at the data structure and observe how the [Hacker News API](h
 Let's extend the composable API constants so it can deal with paginated data:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const DEFAULT_QUERY = 'redux';
 
 const PATH_BASE = 'https://hn.algolia.com/api/v1';
@@ -643,7 +643,7 @@ const PARAM_PAGE = 'page=';
 Now you can use the new constant to add the page parameter to your API request:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const url = `${PATH_BASE}${PATH_SEARCH}?${PARAM_SEARCH}${DEFAULT_QUERY}&${PARAM_PAGE}`;
 
 console.log(url);
@@ -653,7 +653,7 @@ console.log(url);
 The `fetchSearchTopStories()` method will take the page as second argument. If you don't provide the second argument, it will fallback to the `0` page for the initial request. Thus the `componentDidMount()` and `onSearchSubmit()` methods fetch the first page on the first request. Every additional fetch should fetch the next page by providing the second argument.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -677,7 +677,7 @@ The page argument uses the JavaScript ES6 default parameter to introduce the fal
 Now you can use the current page from the API response in `fetchSearchTopStories()`. You can use this method in a button to fetch more stories with an `onClick` button handler. Let's use the Button to fetch more paginated data from the Hacker News API. For this, we'll define the `onClick()` handler, which takes the current search term and the next page (current page + 1).
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -715,7 +715,7 @@ In your `render()` method, make sure to default to page 0 when there is no resul
 There is still one step missing, because fetching the next page of data will override your previous page of data. We want to concatenate the old and new list of hits from the local state and new result object, so we'll adjust its functionality to add new data rather than override it.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 setSearchTopStories(result) {
 # leanpub-start-insert
   const { hits, page } = result;
@@ -747,7 +747,7 @@ Fourth, you set the merged hits and page in the local component state.
 Now we'll make one last adjustment. When you try the "More" button it only fetches a few list items. The API URL can be extended to fetch more list items with each request, so we add even more composable path constants:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const DEFAULT_QUERY = 'redux';
 # leanpub-start-insert
 const DEFAULT_HPP = '100';
@@ -765,7 +765,7 @@ const PARAM_HPP = 'hitsPerPage=';
 Now you can use the constants to extend the API URL.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 fetchSearchTopStories(searchTerm, page = 0) {
   // be careful with the "\" which shows up in the PDF/print version of the book
   // it's only a line break a should not be in the actual code
@@ -797,7 +797,7 @@ To have a client cache for each result, you have to store multiple `results` rat
 At the moment, your result in the local state looks like this:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 result: {
   hits: [ ... ],
   page: 2,
@@ -807,7 +807,7 @@ result: {
 Imagine you have made two API requests. One for the search term "redux" and another one for "react". The results object should look like the following:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 results: {
   redux: {
     hits: [ ... ],
@@ -824,7 +824,7 @@ results: {
 Let's implement a client-side cache with React `setState()`. First, rename the `result` object to `results` in the initial component state. Second, define a temporary `searchKey` to store each `result`.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -850,7 +850,7 @@ class App extends Component {
 The `searchKey` has to be set before each request is made. It reflects the `searchTerm`. Understanding why we don't use `searchTerm` here is a crucial part to understand before continuing with the implementation. The `searchTerm` is a fluctuant variable, because it gets changed every time you type into the search input field. We want a non fluctuant variable that determines the recent submitted search term to the API and can be used to retrieve the correct result from the map of results. It is a pointer to your current result in the cache, which can be used to display the current result in the `render()` method.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 componentDidMount() {
   const { searchTerm } = this.state;
 # leanpub-start-insert
@@ -872,7 +872,7 @@ onSearchSubmit(event) {
 Now we will change where the result is stored to the local component state. It should store each result by `searchKey`.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -916,7 +916,7 @@ Second, the old hits have to get merged with the new hits as before. But this ti
 Third, a new result can be set in the `results` map in the state. Let's examine the `results` object in `setState()`.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 results: {
   ...results,
   [searchKey]: { hits: updatedHits, page }
@@ -930,7 +930,7 @@ The upper part needs to spread all other results by `searchKey` in the state usi
 Now you store all results by search term. That's the first step to enable your cache. In the next step, you can retrieve the result depending on the non fluctuant `searchKey` from your map of results. That's why you had to introduce the `searchKey` in the first place as non fluctuant variable. Otherwise, the retrieval would be broken when you would use the fluctuant `searchTerm` to retrieve the current result, because this value might change when we use the Search component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -987,7 +987,7 @@ The search functionality should store all results from the Hacker News API now.
 Now, we can see the `onDismiss()` method needs improvement, as it still deals with the `result` object. We want it deal with multiple `results`:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
   onDismiss(id) {
 # leanpub-start-insert
     const { searchKey, results } = this.state;
@@ -1013,7 +1013,7 @@ Check to make sure the "Dismiss" button is working again.
 Note that nothing will stop the application from sending an API request on each search submit. Though there might be already a result, there is no check that prevents the request, so the cache functionality is not complete yet. It caches the results, but it doesn't make use of them. The last step is to prevent the API request when a result is available in the cache:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   constructor(props) {
@@ -1067,7 +1067,7 @@ In this chapter, we introduce an efficient solution to add error handling for yo
 Now, we'll implement it in the App component, since that's where we fetch data from the Hacker News API. First, introduce the error in the local state. It is initialized as null, but will be set to the error object in case of an error.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   constructor(props) {
     super(props);
@@ -1092,7 +1092,7 @@ class App extends Component {
 Second, use the catch block in your native fetch to store the error object in the local state by using `setState()`. Every time the API request isn't successful, the catch block is executed.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1117,7 +1117,7 @@ class App extends Component {
 Third, retrieve the error object from your local state in the `render()` method, and display a message in case of an error using React's conditional rendering.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1152,14 +1152,14 @@ class App extends Component {
 If you want to test that your error handling is working, change the API URL to something non-existent to force an error.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const PATH_BASE = 'https://hn.mydomain.com/api/v1';
 ~~~~~~~~
 
 Now you should see an error message instead of your application. It's up to you where you want to place the conditional rendering for the error message. In this case, the app is overridden by the error message, but that wouldn't be the best user experience. The remaining application would still be visible so the user knows it's still running:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -1210,7 +1210,7 @@ class App extends Component {
 **Remember** to revert the URL for the API to the existent one:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const PATH_BASE = 'https://hn.algolia.com/api/v1';
 ~~~~~~~~
 
@@ -1238,7 +1238,7 @@ npm install axios
 Second, import axios in your App component's file:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 # leanpub-start-insert
 import axios from 'axios';
@@ -1251,7 +1251,7 @@ import './App.css';
 You can use axios instead of `fetch()`, and its usage looks almost identical to the native fetch API. It takes the URL as argument and returns a promise. You don't have to transform the returned response to JSON anymore, since axios wraps the result into a `data` object in JavaScript. Just make sure to adapt your code to the returned data structure:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...

--- a/manuscript/chapter4.md
+++ b/manuscript/chapter4.md
@@ -17,7 +17,7 @@ The following examples showcase the statements by sharing one or multiple variab
 The act of exporting one or multiple variables is called a named export:
 
 {title="Code Playground: file1.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const firstname = 'Robin';
 const lastname = 'Wieruch';
 
@@ -27,7 +27,7 @@ export { firstname, lastname };
 And import them in another file with a relative path to the first file.
 
 {title="Code Playground: file2.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import { firstname, lastname } from './file1.js';
 
 console.log(firstname);
@@ -37,7 +37,7 @@ console.log(firstname);
 You can also import all exported variables from another file as one object.
 
 {title="Code Playground: file2.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import * as person from './file1.js';
 
 console.log(person.firstname);
@@ -47,7 +47,7 @@ console.log(person.firstname);
 Imports can have aliases, which are necessary when we import functionalities from multiple files that have the same named export.
 
 {title="Code Playground: file2.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import { firstname as username } from './file1.js';
 
 console.log(username);
@@ -61,7 +61,7 @@ There is also the `default` statement, which can be used for a few cases:
 * to have a fallback import functionality
 
 {title="Code Playground: file1.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const robin = {
   firstname: 'Robin',
   lastname: 'Wieruch',
@@ -73,7 +73,7 @@ export default robin;
 You have to leave out the curly braces to import the default export.
 
 {title="Code Playground: file2.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import developer from './file1.js';
 
 console.log(developer);
@@ -83,7 +83,7 @@ console.log(developer);
 The import name can differ from the exported default name, and it can be used with the named export and import statements:
 
 {title="Code Playground: file1.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const firstname = 'Robin';
 const lastname = 'Wieruch';
 
@@ -103,7 +103,7 @@ export default person;
 Import the default or the named exports in another file:
 
 {title="Code Playground: file2.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import developer, { firstname, lastname } from './file1.js';
 
 console.log(developer);
@@ -115,7 +115,7 @@ console.log(firstname, lastname);
 You can spare the extra lines, and export the variables directly for named exports.
 
 {title="Code Playground: file1.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 export const firstname = 'Robin';
 export const lastname = 'Wieruch';
 ~~~~~~~~
@@ -207,7 +207,7 @@ src/
 Naturally, the modules would split up into *src/constants/* and *src/components/*. The *src/constants/index.js* file could look like the following:
 
 {title="Code Playground: src/constants/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 export const DEFAULT_QUERY = 'redux';
 export const DEFAULT_HPP = '100';
 export const PATH_BASE = 'https://hn.algolia.com/api/v1';
@@ -220,7 +220,7 @@ export const PARAM_HPP = 'hitsPerPage=';
 The *App/index.js* file could import these variables in order to use them.
 
 {title="Code Playground: src/components/App/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import {
   DEFAULT_QUERY,
   DEFAULT_HPP,
@@ -237,7 +237,7 @@ import {
 When you use the *index.js* naming convention, you can omit the filename from the relative path.
 
 {title="Code Playground: src/components/App/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import {
   DEFAULT_QUERY,
   DEFAULT_HPP,
@@ -271,7 +271,7 @@ src/
 The *Buttons/* folder has multiple button components defined in its distinct files. Each file can `export default` the specific component, making it available to *Buttons/index.js*. The *Buttons/index.js* file imports all different button representations and exports them as public module API.
 
 {title="Code Playground: src/Buttons/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import SubmitButton from './SubmitButton';
 import SaveButton from './SaveButton';
 import CancelButton from './CancelButton';
@@ -286,7 +286,7 @@ export {
 Now the *src/App/index.js* can import the buttons from the public module API located in the *index.js* file.
 
 {title="Code Playground: src/App/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import {
   SubmitButton,
   SaveButton,
@@ -297,7 +297,7 @@ import {
 However, it can be seen as bad practice to reach into other files than the *index.js* in the module, as it breaks the rules of encapsulation.
 
 {title="Code Playground: src/App/index.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // bad practice, don't do it
 import SubmitButton from '../Buttons/SubmitButton';
 ~~~~~~~~
@@ -323,7 +323,7 @@ Jest is a JavaScript testing framework used by Facebook. It is used for componen
 Before you can test your first components, you have to export them from your *src/App.js* file. Afterward, you can test them in a different file.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 class App extends Component {
@@ -346,7 +346,7 @@ export {
 In your *App.test.js* file, you will find the first test that came with *create-react-app*. It verifies the App component will render without errors.
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
@@ -383,7 +383,7 @@ npm install --save-dev react-test-renderer
 Now you can extend the App component test with your first snapshot test. First, import the new functionality from the node package and wrap your previous "it"-block for the App component into a descriptive "describe"-block. In this case, the test suite is only for the App component.
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 # leanpub-start-insert
@@ -409,7 +409,7 @@ describe('App', () => {
 Now you can implement your first snapshot test by using a "test"-block:
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
@@ -443,7 +443,7 @@ The `renderer.create()` function creates a snapshot of your App component. It re
 Let's add more tests for our independent components. First, the Search component:
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
@@ -479,7 +479,7 @@ The Search component has two tests similar to the App component. The first test 
 Second, you can test the Button component whereas the same test rules as in the Search component apply.
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 # leanpub-start-insert
 import App, { Search, Button } from './App';
@@ -511,7 +511,7 @@ describe('Button', () => {
 Finally, the Table component that you can pass a bunch of initial props to render it with a sample list.
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 # leanpub-start-insert
 import App, { Search, Button, Table } from './App';
@@ -569,7 +569,7 @@ npm install --save-dev enzyme react-addons-test-utils enzyme-adapter-react-16
 Second, we include it in the test setup and we initialize its adapter.
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
@@ -587,7 +587,7 @@ Enzyme.configure({ adapter: new Adapter() });
 Now you can write your first unit test in the Table "describe"-block. You will use `shallow()` to render your component and assert that the Table was passed two items. The assertion simply checks if the element has two elements with the class `table-row`.
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
@@ -661,7 +661,7 @@ npm install prop-types
 Now, you can import the PropTypes.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import axios from 'axios';
 # leanpub-start-insert
@@ -672,7 +672,7 @@ import PropTypes from 'prop-types';
 Let's start to assign a props interface to the components:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Button = ({
   onClick,
   className = '',
@@ -714,7 +714,7 @@ You already used the `node` PropType for the Button component. There are more Pr
 At the moment, all the defined PropTypes for the Button are optional. The parameters can be `null` or `undefined`. But for several props you want to enforce that they be defined. To do this, we make it a requirement that these props are passed to the component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 Button.propTypes = {
 # leanpub-start-insert
   onClick: PropTypes.func.isRequired,
@@ -729,7 +729,7 @@ Button.propTypes = {
 The `className` is not required, because it can default to an empty string. Next you will define a PropType interface for the Table component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 Table.propTypes = {
   list: PropTypes.array.isRequired,
@@ -741,7 +741,7 @@ Table.propTypes = {
 You can define the content of an array PropType more explicitly:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 Table.propTypes = {
   list: PropTypes.arrayOf(
     PropTypes.shape({
@@ -761,7 +761,7 @@ Only the `objectID` is required, because some of the code depends on it. The oth
 You can also define default props in your component. The `className` property has an ES6 default parameter in the component signature:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Button = ({
   onClick,
   className = '',
@@ -773,7 +773,7 @@ const Button = ({
 Replace it with the internal React default prop:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const Button = ({
   onClick,

--- a/manuscript/chapter5.md
+++ b/manuscript/chapter5.md
@@ -15,7 +15,7 @@ We'll use the Search component as an example. When the application renders for t
 The initial step is to refactor the functional stateless component to an ES6 class component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 class Search extends Component {
   render() {
@@ -48,7 +48,7 @@ class Search extends Component {
 The `this` object of an ES6 class component helps us to reference the DOM element with the `ref` attribute.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Search extends Component {
   render() {
     const {
@@ -80,7 +80,7 @@ class Search extends Component {
 Now you can focus the input field when the component mounted by using the `this` object, the appropriate lifecycle method, and the DOM API.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Search extends Component {
 # leanpub-start-insert
   componentDidMount() {
@@ -118,7 +118,7 @@ class Search extends Component {
 The input field should be focused when the application renders. We access to `ref` in a functional stateless component without the `this` object using the following functional stateless component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Search = ({
   value,
   onChange,
@@ -161,7 +161,7 @@ Now we can access the input DOM element. In our case it wouldn't help much since
 Now we get back to the application, where we'll show a loading indicator when a search request submits to the Hacker News API. The request is asynchronous, so you should show your user feedback that something is happening. Let's define a reusable Loading component in your *src/App.js* file.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Loading = () =>
   <div>Loading ...</div>
 ~~~~~~~~
@@ -169,7 +169,7 @@ const Loading = () =>
 Now we need a property to store the loading state. Based on the loading state, we can decide to show the Loading component later.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   constructor(props) {
     super(props);
@@ -195,7 +195,7 @@ class App extends Component {
 The initial value of that `isLoading` property is false. We don't load anything before the App component is mounted. When the request is made, the loading state is set to true. The request will succeed eventually, and you can set the loading state to false.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -232,7 +232,7 @@ class App extends Component {
 In the last step, we used the Loading component in the App component. A conditional rendering based on the loading state will decide whether to show a Loading component or the Button component. The latter is the button to fetch more data.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -288,7 +288,7 @@ HOCs are used for different use cases. They can prepare properties, manage state
 Let's do a simple HOC that takes a component as input and returns a component. You can place it in your *src/App.js* file.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 function withFeature(Component) {
   return function(props) {
     return <Component { ...props } />;
@@ -299,7 +299,7 @@ function withFeature(Component) {
 It is a useful convention to prefix a HOC with `with`. Since you are using JavaScript ES6, you can express the HOC better with an ES6 arrow function.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const withEnhancement = (Component) => (props) =>
   <Component { ...props } />
 ~~~~~~~~
@@ -307,7 +307,7 @@ const withEnhancement = (Component) => (props) =>
 In our example, the input component stays the same as the output, so nothing happens. The output component should show the Loading component when the loading state is true, otherwise it should show the input component. A conditional rendering is a great use case for an HOC.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const withLoading = (Component) => (props) =>
   props.isLoading
@@ -319,7 +319,7 @@ const withLoading = (Component) => (props) =>
 Based on the loading property, you can apply a conditional rendering. The function will return the Loading component or the input component. In general, it can be very efficient to spread an object like the props object in the previous example as input for a component. See the difference in the following code snippet:
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 // before you would have had to destructure the props before passing them
 const { firstname, lastname } = props;
 <UserProfile firstname={firstname} lastname={lastname} />
@@ -331,7 +331,7 @@ const { firstname, lastname } = props;
 We passed all the props including the `isLoading` property by spreading the object into the input component. The input component may not care about the `isLoading` property. You can use the ES6 rest destructuring to avoid it:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const withLoading = (Component) => ({ isLoading, ...rest }) =>
   isLoading
@@ -345,7 +345,7 @@ It takes one property out of the object, but keeps the remaining object, which a
 Now you can use the HOC in JSX. Maybe you want to show either the "More" button or the Loading component. The Loading component is already encapsulated in the HOC, but an input component is missing. For showing either a Button component or a Loading component, the Button is the input component of the HOC. The enhanced output component is a ButtonWithLoading component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Button = ({
   onClick,
   className = '',
@@ -375,7 +375,7 @@ const ButtonWithLoading = withLoading(Button);
 Everything is defined now. As a last step, you have to use the ButtonWithLoading component, which receives the loading state as an additional property. While the HOC consumes the loading property, all other props get passed to the Button component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -444,7 +444,7 @@ npm install lodash
 Now we import the sort functionality of Lodash in your *src/App.js* file:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import axios from 'axios';
 # leanpub-start-insert
@@ -456,7 +456,7 @@ import './App.css';
 Now we have several columns in Table: title, author, comments and points columns. You can define sort functions where each takes a list and returns a list of items sorted by a specific property. Additionally, you will need a default sort function that doesn't sort, but returns the unsorted list. This will be the initial state.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 # leanpub-start-insert
@@ -482,7 +482,7 @@ The `SORTS` object allows you to reference any sort function now.
 Again, the App component is responsible for storing the state of the sort. The initial state will be the default sort function, which doesn't sort at all and returns the input list as output.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 this.state = {
   results: null,
   searchKey: '',
@@ -500,7 +500,7 @@ Once we choose a different `sortKey`, like the `AUTHOR` key, we sort the list wi
 Now we define a new class method in App component that sets a `sortKey` to the local component state, then `sortKey` can be used to retrieve the sorting function to apply it to the list:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   constructor(props) {
 
@@ -533,7 +533,7 @@ class App extends Component {
 The next step is to pass the method and `sortKey` to the Table component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -573,7 +573,7 @@ class App extends Component {
 The Table component is responsible for sorting the list. It takes one of the `SORT` functions by `sortKey` and passes the list as input, after which it keeps mapping over the sorted list.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const Table = ({
   list,
@@ -596,7 +596,7 @@ const Table = ({
 In theory, the list should get sorted by one of the functions. But the default sort is set to `NONE`, so nothing is sorted yet, as nothing executes the `onSort()` method to change the `sortKey`. We extend the Table with a row of column headers that use Sort components in columns to sort each column:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Table = ({
   list,
   sortKey,
@@ -652,7 +652,7 @@ const Table = ({
 Each Sort component gets a specific `sortKey` and the general `onSort()` function. Internally, it calls the method with the `sortKey` to set the specific key.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Sort = ({ sortKey, onSort, children }) =>
   <Button onClick={() => onSort(sortKey)}>
     {children}
@@ -664,7 +664,7 @@ As you can see, the Sort component reuses your common Button component. On a but
 Now we'll improve the look of the button in the column header. Let's give it a proper `className`:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Sort = ({ sortKey, onSort, children }) =>
 # leanpub-start-insert
   <Button
@@ -679,7 +679,7 @@ const Sort = ({ sortKey, onSort, children }) =>
 This was done to improve the UI. The next goal is to implement a reverse sort. The list should perform a reverse sort once you click a Sort component twice. First, you need to define the reverse state with a boolean. The sort can be either reversed or non-reversed.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 this.state = {
   results: null,
   searchKey: '',
@@ -696,7 +696,7 @@ this.state = {
 Now in your sort method, you can evaluate if the list is reverse sorted. It is reverse if the `sortKey` in the state is the same as the incoming `sortKey` and the reverse state is not already set to true.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 onSort(sortKey) {
 # leanpub-start-insert
   const isSortReverse = this.state.sortKey === sortKey && !this.state.isSortReverse;
@@ -708,7 +708,7 @@ onSort(sortKey) {
 Again, we pass the reverse prop to your Table component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -750,7 +750,7 @@ class App extends Component {
 The Table has to have an arrow function block body to compute the data now:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const Table = ({
   list,
@@ -785,7 +785,7 @@ const Table = ({
 Finally, we want to give the user visual feedback to distinguish which column is actively sorted. Each Sort component has its specific `sortKey` already, which can be used to identify the activated sort. We pass the `sortKey` from the internal component state as active sort key to your Sort component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Table = ({
   list,
   sortKey,
@@ -860,7 +860,7 @@ const Table = ({
 Now the user will know whether sort is active based on the `sortKey` and `activeSortKey` . Give your Sort component an extra `className` attribute, in case it is sorted, to give visual feedback:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const Sort = ({
   sortKey,
@@ -896,7 +896,7 @@ npm install classnames
 After installation, we import it on top of the *src/App.js* file.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 import React, { Component } from 'react';
 import axios from 'axios';
 import { sortBy } from 'lodash';
@@ -909,7 +909,7 @@ import './App.css';
 Now we can define `className` with conditional classes:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Sort = ({
   sortKey,
   activeSortKey,
@@ -939,7 +939,7 @@ const Sort = ({
 There will be failing snapshot and unit tests for the Table component. Since we intentionally changed again our component representations, we accept the snapshot tests, but we still need to fix the unit test. In *src/App.test.js* , provide a `sortKey` and the `isSortReverse` boolean for the Table component.
 
 {title="src/App.test.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 ...
 
 describe('Table', () => {

--- a/manuscript/chapter6.md
+++ b/manuscript/chapter6.md
@@ -11,7 +11,7 @@ Moving substate from one component to another is known as *lifting state*. We wa
 Your Table component as a functional stateless component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const Table = ({
   list,
   sortKey,
@@ -33,7 +33,7 @@ const Table = ({
 Your Table component as an ES6 class component:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 class Table extends Component {
   render() {
@@ -61,7 +61,7 @@ class Table extends Component {
 Since you want to deal with state and methods in your component, you have to add a constructor and initial state.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Table extends Component {
 # leanpub-start-insert
   constructor(props) {
@@ -80,7 +80,7 @@ class Table extends Component {
 Now you can move state and class methods with the sort functionality from your App component down to your Table component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Table extends Component {
   constructor(props) {
     super(props);
@@ -113,7 +113,7 @@ class Table extends Component {
 Remember to remove the moved state and `onSort()` class method from your App component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
   constructor(props) {
     super(props);
@@ -142,7 +142,7 @@ class App extends Component {
 You can also make the Table component more lightweight. To do this, we move props that are passed to it from the App component, because they are handled internally in the Table component.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class App extends Component {
 
   ...
@@ -184,7 +184,7 @@ class App extends Component {
 In the Table component, use the internal `onSort()` method and the internal Table state:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 class Table extends Component {
 
   ...
@@ -283,14 +283,14 @@ Lifting state can go the other way as well: from child to parent component. It i
 So far, we have used React `setState()` to manage your internal component state. We can pass an object to the function where it updates partially the local state.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 this.setState({ value: 'hello'});
 ~~~~~~~~
 
 But `setState()` doesn't take only an object. In its second version, you can pass a function to update the state.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 this.setState((prevState, props) => {
   ...
 });
@@ -299,7 +299,7 @@ this.setState((prevState, props) => {
 There is one crucial case where it makes sense to use a function over an object: when you update the state depending on the previous state or props. If you don't use a function, the local state management can cause bugs. The React `setState()` method is asynchronous. React batches `setState()` calls and executes them eventually. Sometimes, the previous state or props changes between before we can rely on it in our `setState()` call.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 const { oneCount } = this.state;
 const { anotherCount } = this.props;
 this.setState({ count: oneCount + anotherCount });
@@ -310,7 +310,7 @@ Imagine that `oneCount` and `anotherCount`, thus the state or the props, change 
 With the function approach, the function in `setState()` is a callback that operates on the state and props at the time of executing the callback function. Even though `setState()` is asynchronous, with a function it takes the state and props at the time when it is executed.
 
 {title="Code Playground",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 this.setState((prevState, props) => {
   const { oneCount } = prevState;
   const { anotherCount } = props;
@@ -321,7 +321,7 @@ this.setState((prevState, props) => {
 In our code, the `setSearchTopStories()` method relies on the previous state, and this is a good example to use a function over an object in `setState()`. Right now, it looks like the following code:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 setSearchTopStories(result) {
   const { hits, page } = result;
   const { searchKey, results } = this.state;
@@ -348,7 +348,7 @@ setSearchTopStories(result) {
 Here, we extracted values from the state, but updated the state depending on the previous state asynchronously. Now we'll use the functional approach to prevent bugs from a stale state:
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 setSearchTopStories(result) {
   const { hits, page } = result;
 
@@ -363,7 +363,7 @@ setSearchTopStories(result) {
 We can move the whole block we implemented into the function by directing it to operate on the `prevState` instead of the `this.state`.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 setSearchTopStories(result) {
   const { hits, page } = result;
 
@@ -395,7 +395,7 @@ setSearchTopStories(result) {
 That will fix the issue with a stale state, but there is still one more improvement. Since it is a function, you can extract the function for improved readability. One more advantage to use a function over an object is that function can live outside of the component. We still have to use a higher-order function to pass the result to it since we want to update the state based on the fetched result from the API.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 setSearchTopStories(result) {
   const { hits, page } = result;
   this.setState(updateSearchTopStoriesState(hits, page));
@@ -405,7 +405,7 @@ setSearchTopStories(result) {
 The `updateSearchTopStoriesState()` function has to return a function. It is a higher-order function that can be defined outside the App component. Note how the function signature changes slightly now.
 
 {title="src/App.js",lang="javascript"}
-~~~~~~~~
+~~~~~~~~js
 # leanpub-start-insert
 const updateSearchTopStoriesState = (hits, page) => (prevState) => {
   const { searchKey, results } = prevState;


### PR DESCRIPTION
I enabled syntax highlighting on the `html` and `js` snippets throughout the book by adding file extensions to the beginning of code blocks. This change allows GitHub to render each code block with appropriate syntax highlighting.